### PR TITLE
Fix wrong branch in root install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ clone_repo() {
   # Clone the startup animations repository
   if [[ ! -d "$HOME/homebrew/startup_animations" ]]; then
     echo ":: Installing to $HOME/homebrew/startup_animations"
-    git clone https://github.com/kageurufu/steamdeck_startup_animations "$HOME/homebrew/startup_animations"
+    git clone https://github.com/kageurufu/steamdeck_startup_animations -b root "$HOME/homebrew/startup_animations"
     cd "$HOME/homebrew/startup_animations"
   else
     echo ":: Updating $HOME/homebrew/startup_animations"


### PR DESCRIPTION
found that in the install script the wrong branch was being installed, even though the install script has options for root and rootless and points to a directory that doesn't exist in main