### PR TITLE
Set library.css file size to what it was before edit

### DIFF
--- a/randomize_deck_startup.sh
+++ b/randomize_deck_startup.sh
@@ -22,6 +22,7 @@ msg2() {
 
 DECK_STARTUP_FILE="/home/deck/.steam/steam/steamui/movies/deck_startup.webm"
 DECK_LIBRARY_CSS_FILE="/home/deck/.steam/steam/steamui/css/library.css"
+DECK_LIBRARY_CSS_FILE_SIZE=$(stat -c%s $DECK_LIBRARY_CSS_FILE)
 DECK_STARTUP_FILE_SIZE=1840847
 DECK_STARTUP_STOCK_MD5="4ee82f478313cf74010fc22501b40729"
 
@@ -51,6 +52,7 @@ replace_css_video() {
   OLD_CSS="video{flex-grow:0;width:300px;height:300px;z-index:10}"
   NEW_CSS="video{flex-grow:1;width:100%;height:100%;z-index:10}  "
   sed -i.bak -e "s/$OLD_CSS/$NEW_CSS/" $DECK_LIBRARY_CSS_FILE
+  truncate --size=$DECK_LIBRARY_CSS_FILE_SIZE $DECK_LIBRARY_CSS_FILE
 }
 
 check_backup


### PR DESCRIPTION
If the file isn't this size, it resets the whole environment. Since it can change, we want to grab it dynamically and set it to the value prior any edits.